### PR TITLE
Fix TypeScript and build errors for Vercel deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1615,6 +1615,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.10.tgz",
+      "integrity": "sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
@@ -3526,6 +3537,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -9050,6 +9068,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9058,6 +9086,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/spawn-command": {
@@ -9385,6 +9424,32 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/terser": {
+      "version": "5.43.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.14.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11296,6 +11361,8 @@
         "globals": "^16.3.0",
         "jsdom": "^24.0.0",
         "msw": "^2.0.0",
+        "terser": "^5.43.1",
+        "typescript": "^5.8.3",
         "typescript-eslint": "^8.35.1",
         "vite": "^6.0.0",
         "vitest-axe": "^0.1.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b tsconfig.build.json && vite build",
     "build:simple": "node build.js",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -19,21 +19,23 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@testing-library/jest-dom": "^6.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@vitest/ui": "^2.0.0",
-    "jsdom": "^24.0.0",
-    "msw": "^2.0.0",
-    "vitest-axe": "^0.1.0",
     "@vitejs/plugin-react": "^4.6.0",
+    "@vitest/ui": "^2.0.0",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jsdom": "^24.0.0",
+    "msw": "^2.0.0",
+    "terser": "^5.43.1",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/packages/ui/src/components/LiveTestStatus.tsx
+++ b/packages/ui/src/components/LiveTestStatus.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styles from './LiveTestStatus.module.css'
 
 interface ServiceTrace {
+  type: string
   service: string
   method: string
   requestData?: any

--- a/packages/ui/src/components/PromptForm/PromptForm.tsx
+++ b/packages/ui/src/components/PromptForm/PromptForm.tsx
@@ -26,7 +26,7 @@ export function PromptForm({ onSubmit, isLoading, error, stage }: PromptFormProp
     'advanced',
   )
   const [outputFormat, setOutputFormat] = useLocalStorage('promptdial-format', 'markdown')
-  const [taskType] = useState<string | undefined>(undefined)
+  const [taskType] = useState<'creative' | 'analytical' | 'coding' | 'general' | undefined>(undefined)
   const [validationError, setValidationError] = useState<string>('')
   const [showAdvanced, setShowAdvanced] = useState(false)
 
@@ -73,7 +73,7 @@ export function PromptForm({ onSubmit, isLoading, error, stage }: PromptFormProp
       prompt: prompt.trim(),
       targetModel: model,
       optimizationLevel: level,
-      ...(taskType && taskType !== 'undefined' && { taskType }),
+      ...(taskType && { taskType }),
     }
 
     onSubmit(request)

--- a/packages/ui/src/components/ResultsList/ResultsList.tsx
+++ b/packages/ui/src/components/ResultsList/ResultsList.tsx
@@ -133,7 +133,7 @@ export function ResultsList({ isLoading, results, error, onCopy }: ResultsListPr
               <div className={styles.scoreSection}>
                 <span className={styles.scoreLabel}>Quality Score</span>
                 <span
-                  className={`${styles.scoreValue} ${styles[bestVariant.quality?.score >= 80 ? 'high' : bestVariant.quality?.score >= 60 ? 'medium' : 'low']}`}
+                  className={`${styles.scoreValue} ${styles[(bestVariant.quality?.score ?? 0) >= 80 ? 'high' : (bestVariant.quality?.score ?? 0) >= 60 ? 'medium' : 'low']}`}
                 >
                   {bestVariant.quality?.score || 0}/100
                 </span>
@@ -205,7 +205,7 @@ export function ResultsList({ isLoading, results, error, onCopy }: ResultsListPr
                 <div className={styles.stat}>
                   <span className={styles.statLabel}>Average Score</span>
                   <span className={styles.statValue}>
-                    {Math.round(results.summary.averageScore)}
+                    {Math.round(results.summary.averageScore ?? 0)}
                   </span>
                 </div>
                 {results.metadata?.activeProvider && (

--- a/packages/ui/src/components/TestDashboard.tsx
+++ b/packages/ui/src/components/TestDashboard.tsx
@@ -27,6 +27,16 @@ type ModelProvider = 'openai' | 'anthropic' | 'google'
 
 interface TestEvent {
   type: string
+  service: string
+  method?: string
+  requestData?: any
+  responseData?: any
+  responseTime?: number
+  timestamp: Date
+  techniques?: string[]
+  quality?: number
+  variantId?: string
+  taskType?: string
   [key: string]: any
 }
 
@@ -162,7 +172,7 @@ export function TestDashboard() {
         {/* Input Section */}
         <div className="mb-8">
           <Suspense fallback={<ComponentLoader />}>
-            <PromptInput onSubmit={startTest} isDisabled={testState.status === 'testing'} />
+            <PromptInput onSubmit={(prompt) => startTest(prompt)} disabled={testState.status === 'testing'} />
           </Suspense>
         </div>
 
@@ -195,9 +205,8 @@ export function TestDashboard() {
               {Object.entries(testState.results.original).map(([provider, result]) => (
                 <Suspense key={provider} fallback={<ComponentLoader />}>
                   <ProviderCard
-                    provider={provider as ModelProvider}
-                    result={result}
-                    isOriginal={true}
+                    provider={provider}
+                    original={result}
                   />
                 </Suspense>
               ))}
@@ -208,9 +217,8 @@ export function TestDashboard() {
               <div key={index} className="border rounded-lg p-6 bg-white shadow-sm">
                 <Suspense fallback={<ComponentLoader />}>
                   <OptimizedPromptViewer
-                    variant={variant.variant}
-                    quality={variant.quality}
-                    results={variant.results}
+                    variants={[{variant: variant.variant, quality: variant.quality}]}
+                    bestIndex={0}
                   />
                 </Suspense>
               </div>
@@ -220,8 +228,10 @@ export function TestDashboard() {
             <div className="mt-8">
               <Suspense fallback={<ComponentLoader />}>
                 <ComparisonChart
-                  originalResults={testState.results.original}
-                  optimizedResults={testState.results.optimized}
+                  results={{
+                    original: testState.results.original,
+                    optimized: testState.results.optimized
+                  }}
                 />
               </Suspense>
             </div>

--- a/packages/ui/src/components/common/ErrorBoundary.tsx
+++ b/packages/ui/src/components/common/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import { Component, ReactNode } from 'react'
+import { Component } from 'react'
+import type { ReactNode } from 'react'
 import { ErrorMessage } from './ErrorMessage'
 
 interface Props {

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/packages/ui/src/test-dashboard-main.tsx
+++ b/packages/ui/src/test-dashboard-main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import TestDashboardApp from './TestDashboardApp.tsx'
+import TestDashboardApp from './TestDashboardApp'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/packages/ui/src/types/promptdial.ts
+++ b/packages/ui/src/types/promptdial.ts
@@ -55,6 +55,10 @@ export interface OptimizedResult {
     bestScore?: number
     averageScore?: number
   }
+  metadata?: {
+    optimizationMode?: string
+    activeProvider?: string
+  }
 }
 
 export interface PromptDialOptions {

--- a/packages/ui/src/vite-env.d.ts
+++ b/packages/ui/src/vite-env.d.ts
@@ -1,0 +1,25 @@
+/// <reference types="vite/client" />
+
+// CSS modules
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string }
+  export default classes
+}
+
+// Regular CSS files
+declare module '*.css' {
+  const css: string
+  export default css
+}
+
+// Environment variables
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string
+  readonly VITE_OPENAI_API_KEY?: string
+  readonly VITE_ANTHROPIC_API_KEY?: string
+  readonly VITE_GOOGLE_API_KEY?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/packages/ui/src/vitest.d.ts
+++ b/packages/ui/src/vitest.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom" />
+
+import type { TestingLibraryMatchers } from '@testing-library/jest-dom/matchers'
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends jest.Matchers<void, T>, TestingLibraryMatchers<T, void> {}
+}

--- a/packages/ui/tsconfig.app.json
+++ b/packages/ui/tsconfig.app.json
@@ -15,6 +15,7 @@
     "noUncheckedSideEffectImports": true,
     "paths": {
       "@/*": ["./src/*"],
+      "@/tests/*": ["./tests/*"],
       "@components/*": ["./src/components/*"],
       "@hooks/*": ["./src/hooks/*"],
       "@utils/*": ["./src/utils/*"],
@@ -22,5 +23,5 @@
     },
     "baseUrl": "."
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -3,6 +3,7 @@
   "exclude": ["src/**/*.test.*", "src/**/*.spec.*", "tests/**/*"],
   "compilerOptions": {
     "noEmit": false,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": false
   }
 }

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
       '@hooks': resolve(__dirname, './src/hooks'),
       '@utils': resolve(__dirname, './src/utils'),
       '@types': resolve(__dirname, './src/types'),
-      promptdial: resolve(__dirname, '../core/src/index.ts'),
+      promptdial: resolve(__dirname, './src/types/promptdial.ts'),
+      '@promptdial/shared': resolve(__dirname, '../shared/src/index.ts'),
     },
   },
   server: {
@@ -32,8 +33,6 @@ export default defineConfig({
         manualChunks: {
           // Vendor chunks for better caching
           vendor: ['react', 'react-dom'],
-          // PromptDial core functionality
-          promptdial: ['promptdial'],
           // Chart libraries (if used)
           charts: ['chart.js', 'recharts'].filter((pkg) => {
             try {

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@/tests': path.resolve(__dirname, './tests'),
     },
   },
 })


### PR DESCRIPTION
## Summary
- Fixed all TypeScript errors preventing the UI package from building on Vercel
- Added necessary type declarations for CSS modules and test utilities
- Resolved component type mismatches and missing dependencies

## Changes Made
1. **Type Declarations**
   - Added `vite-env.d.ts` for CSS module type declarations
   - Added `vitest.d.ts` for test matcher types

2. **TypeScript Configuration**
   - Updated `tsconfig.app.json` to include tests directory and path aliases
   - Fixed `tsconfig.build.json` to disable `allowImportingTsExtensions` for builds
   - Added path resolution for test utilities

3. **Component Fixes**
   - Added `metadata` property to `OptimizedResult` interface
   - Fixed `ServiceTrace` type to include required `type` property
   - Resolved prop type mismatches in `TestDashboard` component
   - Fixed taskType typing in `PromptForm`
   - Handled undefined values in `ResultsList`

4. **Build Configuration**
   - Updated Vite config to alias `promptdial` to local types instead of server-side code
   - Removed server-side dependencies from browser bundle
   - Installed missing dependencies: `typescript` and `terser`

5. **Import Fixes**
   - Removed `.tsx` extensions from imports
   - Fixed ReactNode type-only import for `verbatimModuleSyntax`

## Test plan
- [x] Run `npm run build` locally - builds successfully
- [ ] Deploy to Vercel - should now build without errors
- [ ] Verify UI functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)