### PR TITLE
Add Prompt Dial v3 Product Documentation

### DIFF
--- a/docs/PRD-v3.md
+++ b/docs/PRD-v3.md
@@ -1,0 +1,153 @@
+# Product Requirements Document
+
+**Product Name:** Prompt Dial v3 ("Prompt-Native Orchestrator")
+**Author:** Eskender (Product Lead)
+**Last Updated:** 2025-08-07
+
+---
+
+## 1 · Executive Summary
+
+Prompt Dial turns a single LLM into its own planner, executor, and verifier.
+All business logic lives inside three prompt shards, while a 50-line wrapper merely forwards JSON, persists `state`, and logs `events`. No micro-services, no server-side plugins.
+
+---
+
+## 2 · Goals & Non-Goals
+
+| | In Scope (Goals) | Out of Scope |
+| -------------------------------------------------------------------------------- | ------------------------------------ | ------------ |
+| **G1** Declarative workflow in prompts (Planner → Executor → Verifier). | External orchestration engines. | |
+| **G2** Kernel contract: tool registry, policy, JSON wire schema. | Arbitrary tool marketplace. | |
+| **G3** Zero "hidden" chain-of-thought; verifiable audit trail. | Fine-tuned private models. | |
+| **G4** Latency ≤ 3 LLM calls for 95 % of tasks. | Real-time streaming token response. | |
+| **G5** Drop run-time code execution (remove `run_python`) to stay prompt-native. | Heavy data science pipelines in-app. | |
+
+---
+
+## 3 · Success Metrics
+
+| Metric | Target (30 days post-GA) |
+| -------------------------------------------------------- | ------------------------ |
+| **P0** Tasks completing without manual retry | ≥ 92 % |
+| **P1** Avg. total tokens per task (incl. clarifications) | ≤ 2500 |
+| **P2** Clarification loop length | ≤ 3 turns median |
+| **P3** Policy-violation escapes to user | 0 (block-rate = 100 %) |
+| **P4** "Helpful" CSAT on delivered answers | ≥ 4.3 / 5 |
+
+---
+
+## 4 · Personas
+
+| Persona | Need | Key Pain-Point Today |
+| ------------------------- | ------------------------------------- | ---------------------------------------- |
+| **Power Prompt Engineer** | Compose multi-step content pipelines. | Juggling separate agents + brittle JSON. |
+| **Data-lite Analyst** | Summaries, tweet threads, memos. | Doesn't want to debug Python sandboxes. |
+| **Ops Auditor** | Verify no policy breaches. | Black-box chain-of-thought. |
+
+---
+
+## 5 · User Stories
+
+1. *As a prompt engineer* I paste a long research URL → get a five-step plan, execution, and verified summary in one chat.
+2. *As an analyst* I can inspect the `events` log for each step to understand provenance.
+3. *As compliance* I see a refusal if the request asks for disallowed content, not hidden CoT.
+
+---
+
+## 6 · Functional Requirements
+
+### 6.1 Kernel (Static System Prompt)
+
+* Defines persona ("senior technical architect").
+* Registers **fetch\_web(url\:str)** only.
+* Policy matrix: privacy, self-harm, illicit behaviour, PII.
+* Output schema (version-tagged):
+
+```json
+{ ok, state, events, next_action, final_answer, schema_version }
+```
+* Token hard-cap: 1800 / response.
+
+### 6.2 Planner Prompt
+
+* Input: `user_goal`, `state` (empty on first call).
+* Output: ordered `plan[]`, sets `next_action:"execute"`.
+
+### 6.3 Executor Prompt
+
+* Executes `plan[cursor]`.
+* Handles tool errors (`fetch_web.ok == false`) by logging WARNING and retrying once.
+* Moves to Verifier when `cursor == plan.length`.
+
+### 6.4 Verifier Prompt
+
+* Checklist: policy, length, factual plausibility.
+* On pass → `next_action:"done"`.
+* On fail → regenerate (max 1) or `safe_refuse`.
+
+### 6.5 Wrapper (Thin Code)
+
+* Adds UTC timestamp to each `events` entry.
+* Enforces 5-second HTTP timeout.
+* Persists `{prompts,responses}` for replay.
+
+---
+
+## 7 · Non-Functional Requirements
+
+| Category | Requirement |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Security** | No code execution; network only via `fetch_web` with allow-list domains (configurable). |
+| **Reliability** | Wrapper retries LLM call once on 5xx / timeout; idempotent on duplicate calls via `state` hash. |
+| **Observability** | Structured JSON logs; Grafana dashboards for P0–P3 metrics. |
+| **Extensibility** | New tools require kernel update + `schema_version` bump; backward-compat wrapper accepts older version for 90 days. |
+
+---
+
+## 8 · Technical Architecture
+
+```
+User ↔ Wrapper (Python 3.11, ~50 LOC)
+│
+├── call #1 → LLM (Planner prompt)
+├── call #2…N → LLM (Executor prompt, looping)
+└── call #last → LLM (Verifier prompt)
+```
+
+*State* and *events* travel as JSON; wrapper does no business logic.
+
+---
+
+## 9 · Open Questions
+
+1. **Policy Source-of-Truth:** adopt OpenAI 2025-06 spec verbatim or trim to minimal subset?
+2. **fetch\_web allow-list:** static list in env-var vs. dynamic user override?
+3. **Clarification Budget:** hard-limit of 3 questions or adaptive based on token usage?
+4. **Trace Exposure:** will end-users download full JSON trace or only see `final_answer`?
+
+---
+
+## 10 · Assumptions
+
+* All target LLMs exhibit deterministic tool-call syntax parsing.
+* Users accept occasional numeric inaccuracies (< 1 %) without `run_python`.
+* Wrapper runs in a container with egress restricted to approved domains.
+
+---
+
+## 11 · Milestones & Timeline
+
+| Date | Milestone |
+| ---------- | ------------------------------------------------------ |
+| **Aug 15** | Finalise policy matrix & allow-list. |
+| **Aug 22** | Implement wrapper v0.9 (logging + retries). |
+| **Aug 29** | Kernel + Planner + Executor + Verifier prompts frozen. |
+| **Sep 05** | Internal dogfood → collect P0 metrics. |
+| **Sep 12** | GA release if P0–P2 targets met. |
+
+---
+
+### Appendix A · Kernel Draft (v3-RC1)
+
+*(See previous message for full text — ready for red-team review.)*

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1,0 +1,90 @@
+# Prompt Dial v3 — Project Plan (Prompt-Native, Agent-First)
+
+### Guiding Principle
+
+*All logic lives in prompts; the wrapper is a thin transport layer.*
+Epics are organised around the LLM's responsibilities, not traditional SDLC phases. Each story can be implemented by an autonomous coding agent (self-planning, self-executing).
+
+---
+
+### Epic 1 · Kernel Contract & Policy
+
+**Goal:** lock the immutable "constitution" every prompt shard must obey.
+
+| Story ID | Description | Acceptance Criteria |
+| -------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| K-1 | Draft policy matrix (privacy, disallowed content, refusal template). | Verifier rejects any answer that violates matrix; test prompts pass. |
+| K-2 | Versioned JSON wire schema (`schema_version`, deterministic key order). | Regression suite decodes v3 and v2; no wrapper changes needed. |
+| K-3 | Remove `run_python`; final tool registry = `fetch_web`. | Planner never emits code-execution steps in ≥ 100 random tasks. |
+| K-4 | Token budget guardrail (≤ 1800 tokens / turn). | Executor auto-splits answers > 1700 tokens into continuation plan. |
+
+---
+
+### Epic 2 · Planner Prompt (LLM Call #1)
+
+| Story ID | Description | Acceptance Criteria |
+| -------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| P-1 | Self-consistency planning: generate ≥ 3 candidate plans → converge. | Plans converge to identical step list in stochastic test (T=0.7). |
+| P-2 | Gap-scan → clarify loop (max 3 questions). | 95 % of tasks lock within 3 clarifications; fallback to partial plan. |
+| P-3 | Plan validation rubric (no forbidden tools, no chain-of-thought). | Static analysis script flags zero violations in sample corpus. |
+
+---
+
+### Epic 3 · Executor Prompt (LLM Call #2‥N)
+
+| Story ID | Description | Acceptance Criteria |
+| -------- | ------------------------------------------------------ | ------------------------------------------------------------- |
+| E-1 | Deterministic tool call syntax for `fetch_web`. | Wrapper regex extracts URL reliably in sandbox tests. |
+| E-2 | Error-aware step handling (`ok:false`, `error` field). | Executor retries once, logs WARN, skips or aborts per policy. |
+| E-3 | State mutation contract (`cursor`, `artifacts`). | End-to-end test shows complete trace with ordered artifacts. |
+
+---
+
+### Epic 4 · Verifier Prompt (LLM Call #last)
+
+| Story ID | Description | Acceptance Criteria |
+| -------- | ------------------------------------------------------------- | --------------------------------------------------------- |
+| V-1 | Checklist-driven audit: policy, factual plausibility, length. | Random injection of policy violation → Verifier refuses. |
+| V-2 | Safe-completion branch (`next_action:"safe_refuse"`). | Wrapper surfaces safe-refusal payload; no raw CoT leaked. |
+| V-3 | Single regeneration attempt, then escalate. | Infinite-loop guard passes chaos-monkey test. |
+
+---
+
+### Epic 5 · Wrapper & Observability (≈50 LOC)
+
+| Story ID | Description | Acceptance Criteria |
+| -------- | ------------------------------------------------ | ---------------------------------------------------------------- |
+| W-1 | Timestamped JSON event log (`t, lvl, msg`). | Grafana dashboard displays P0–P3 metrics in real-time. |
+| W-2 | Idempotent retry on LLM 5xx/timeouts (back-off). | Replay test shows no duplicate side-effects. |
+| W-3 | Domain allow-list for `fetch_web`; 5 s timeout. | Attempt to access disallowed domain → Executor WARN, plan abort. |
+
+---
+
+### Epic 6 · Red-Team & Evaluation Harness
+
+| Story ID | Description | Acceptance Criteria |
+| -------- | ---------------------------------------------------------------- | --------------------------------------------- |
+| R-1 | Prompt-injection battery (override persona, leak CoT). | Kernel resists 100 % of injections. |
+| R-2 | Safety-policy adversarial test set (self-harm, illicit content). | Verifier safe-refuses every red-flag prompt. |
+| R-3 | Numeric reasoning regression (no `run_python`). | ≤ 1 % arithmetic error on 200-item benchmark. |
+
+---
+
+### Epic 7 · Documentation & Developer UX
+
+| Story ID | Description | Acceptance Criteria |
+| -------- | --------------------------------------------------------------- | ---------------------------------------------------------- |
+| D-1 | **README:** architecture diagram, usage examples, quick-start. | New dev reproduces "summarise + 5 tweets" task in < 5 min. |
+| D-2 | Prompt authoring guide (kernel constraints, negative examples). | Internal team writes a new shard without wrapper changes. |
+| D-3 | Compliance brief (policy summary, audit log format). | Passes legal review for enterprise deployment. |
+
+---
+
+### How Autonomous Coding Agents Execute These Stories
+
+1. **Plan** – Agent reads the story, runs its own Planner prompt to break work into sub-tasks.
+2. **Implement** – Agent edits the prompt files or wrapper code in-place, commits via git.
+3. **Self-Test** – Agent invokes Verifier shard against synthetic test cases it generated.
+4. **Report** – Agent outputs PR diff + JSON trace to human reviewer.
+
+This self-referential loop keeps all logic prompt-native while letting agents own the SDLC.

--- a/docs/prompt-engineering-stack.md
+++ b/docs/prompt-engineering-stack.md
@@ -1,0 +1,156 @@
+# The "Prompt Engineering Stack"
+
+*A layered, end‑to‑end system for writing world‑class prompts*
+
+---
+
+## Layer 0 — Model & Context Selection
+
+1. **Pick a reasoning‑grade model** (e.g., OpenAI o3, Claude Opus 4, Gemini 2.5 Pro).
+2. **Load task context** (domain corpus, tool APIs, retrieval endpoints).
+
+> Without this foundation, higher‑layer tactics deliver diminishing returns.
+
+---
+
+## Layer 1 — Contract‑First Intent Clarification
+
+*(adapted from the "Intent Translator MAX" prompt)*
+
+| Phase | What the model does | Your control signals |
+| ----------------------- | ---------------------------------------------------------------------------- | ----------------------------- |
+| **0 SILENT SCAN** | Lists unknown facts/constraints. | — |
+| **1 CLARIFY LOOP** | Asks one targeted question until ≥ 95 % confidence. | Answer or type `RESET`. |
+| **2 ECHO CHECK** | Returns single‑sentence summary + "✅ YES / ❌ EDITS / 🔧 BLUEPRINT / ⚠ RISK". | Confirm or request sub‑modes. |
+| **3 BLUEPRINT** | Outlines key steps / I‑O schema. | Pause, tweak, lock. |
+| **4 RISK** | Surfaces top 3 failure modes. | Mitigate or revise. |
+| **5 BUILD & SELF‑TEST** | Generates output, runs static checks. | Review deliverable. |
+
+This handshake prevents the #1 failure mode—misaligned intent—before any heavy token spend.
+
+---
+
+## Layer 2 — Prompt Blueprint (P‑I‑R‑O)
+
+Structure every final prompt in **four slots**:
+
+1. **Purpose** – goal, audience, success criteria.
+2. **Instructions** – step order, guardrails/edge‑cases, fallback behaviour.
+3. **Reference** – data snippets, style guides, exemplar Q‑A pairs.
+4. **Output** – format contract (JSON / Markdown / code), length/tone limits.
+
+This mirrors the taxonomy in the Prompt Report's best‑practice guidelines.
+
+---
+
+## Layer 3 — Embedded Reasoning Drivers
+
+*Attach the evidence‑based techniques inside the blueprint's **Instructions** block.*
+
+| Technique | When to embed | Micro‑syntax |
+| ----------------------------------- | --------------------------- | ---------------------------------------------------------- |
+| **Self‑Consistency** | Knowledge & logic questions | "Generate 5 candidate answers; compare & emit consensus." |
+| **Program‑of‑Thought** | Math / data / code | "Write Python to compute … then return result." |
+| **Plan‑Then‑Solve** | Multi‑step tasks | "First produce a numbered plan, wait for ✅, then execute." |
+| **Retrieval‑Augmented (RAG)** | Knowledge‑intensive tasks | "If fact needed, call SEARCH() and cite." |
+| **Chain / Tree / Graph‑of‑Thought** | Complex reasoning trees | "Think step‑by‑step; branch if ambiguity > 0.2." |
+
+---
+
+## Layer 4 — Meta‑Prompting Loops
+
+Leverage the model to improve its own prompt:
+
+1. **Self‑Improvement Loop** – "Here's my current prompt → suggest 3 upgrades → apply best."
+2. **Uncertainty Probe** – "List ambiguous parts & missing info."
+3. **Capability Discovery** – "If unconstrained, how else could you solve this?"
+4. **Explain‑Your‑Work / Socratic Why** – "Why did you choose approach X? What alternatives?"
+
+Meta‑prompting is a formally recognised technique in the literature.
+
+---
+
+## Layer 5 — Auto‑Optimization (Optional)
+
+When scale matters, wrap Layer 4 with automation:
+
+* **APE / GrIPS / AutoPrompt** to generate, score and iterate prompt variants.
+* Reinforcement or evolutionary search on task metrics.
+* Keep a "prompt registry" with version tags, eval traces, and rollback keys.
+
+---
+
+## Layer 6 — Evaluation & Hardening
+
+*Every prompt ships with its own test‑harness.*
+
+| Dimension | Method |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| **Correctness** | Few‑shot hidden tests, gold benchmarks, automatic self‑verification |
+| **Robustness** | Canary phrases, negative examples, anti‑jailbreak rules (see security section of Prompt Report) |
+| **Calibration** | "Give answer + confidence 0‑1; if < 0.6, cite uncertainty source." |
+| **Performance** | Token budget assertions in output block; static code‑lint for program‑of‑thought. |
+
+---
+
+## Copy‑Ready Master Template
+
+```text
+########################################
+# PROMPT BLUEPRINT (P‑I‑R‑O pattern) #
+########################################
+
+PURPOSE
+• Mission: <<crisp objective>>
+• Success criteria: <<measurable>>
+
+INSTRUCTIONS
+1. Contract‑First handshake (CLARIFY → ECHO → YES/EDITS).
+2. Planning: generate step list, wait for ✅LOCK.
+3. Execution: follow Program‑of‑Thought (Python) or RAG as needed.
+4. Self‑Consistency: produce N variants, reconcile → final_answer.
+5. Output must follow schema in OUTPUT section.
+6. Guardrails:
+– If unable → respond "UNCERTAIN".
+– Forbidden: … # security
+– Edge‑cases: … # domain‑specific
+
+REFERENCE
+<<insert facts, style snippets, exemplar Q‑A, API docs>>
+
+OUTPUT
+```json
+{
+"answer": "...",
+"reasoning": "...",
+"confidence": 0.0‑1.0
+}
+```
+
+########################################
+```
+
+---
+
+## Quick‑Start Checklist
+
+| ✔︎ | Question |
+|----|----------|
+| ☐ | Have I picked a reasoning‑grade model & loaded context? |
+| ☐ | Did the CLARIFY loop hit 95 % confidence? |
+| ☐ | Does the blueprint include P‑I‑R‑O slots? |
+| ☐ | Which reasoning driver(s) are embedded? |
+| ☐ | Is a meta‑prompting self‑improvement hook present? |
+| ☐ | Are robustness tests & uncertainty outputs defined? |
+
+---
+
+## How to Use This Stack
+
+1. **Start at Layer 1** with the Contract‑First scaffold; lock intent.
+2. **Fill P‑I‑R‑O** using domain artefacts.
+3. **Attach Layer 3 drivers** relevant to task type.
+4. **Run meta loop** until the prompt scores ≥ pass on your eval harness.
+5. **Snapshot & version**; monitor drift over time.
+
+Execute these layers faithfully and you'll be writing—by design—the **best fucking prompts on the planet**.


### PR DESCRIPTION
## Summary
- Add comprehensive Product Requirements Document (PRD-v3.md) defining the prompt-native orchestrator architecture
- Add detailed project plan organizing development into LLM-responsibility epics
- Add prompt engineering stack guide with layered best practices and templates

## Test plan
- [x] Verify all markdown files render correctly
- [x] Confirm documentation structure follows project standards
- [x] Review content for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.ai/code)