### PR TITLE
feat: Add orchestrator test toggle to Anthropic test page

### DIFF
--- a/app/api/test-orchestrator/route.ts
+++ b/app/api/test-orchestrator/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { OrchestrationResponse, OrchestrationState, OrchestrationEvent } from '@/lib/orchestrator/types';
+
+// Mock orchestrator for testing without database/OpenAI dependencies
+async function mockOrchestrate(userGoal: string, model: string): Promise<OrchestrationResponse> {
+  // Simulate some processing time
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // Create mock events
+  const events: OrchestrationEvent[] = [
+    {
+      id: '1',
+      runId: 'test-run-' + Date.now(),
+      type: 'orchestration_started',
+      data: { goal: userGoal, model },
+      timestamp: new Date()
+    },
+    {
+      id: '2',
+      runId: 'test-run-' + Date.now(),
+      type: 'plan_generated',
+      data: { steps: 2 },
+      timestamp: new Date()
+    },
+    {
+      id: '3',
+      runId: 'test-run-' + Date.now(),
+      type: 'step_executed',
+      data: { step: 1, description: 'Processing request' },
+      timestamp: new Date()
+    },
+    {
+      id: '4',
+      runId: 'test-run-' + Date.now(),
+      type: 'orchestration_completed',
+      data: { success: true },
+      timestamp: new Date()
+    }
+  ];
+
+  // Create mock state
+  const state: OrchestrationState = {
+    runId: 'test-run-' + Date.now(),
+    userGoal: userGoal,
+    plan: [
+      {
+        id: 'step-1',
+        description: 'Analyze the request',
+        toolCall: {
+          tool: 'analyzer',
+          params: { query: userGoal }
+        }
+      },
+      {
+        id: 'step-2',
+        description: 'Generate response using ' + model,
+        toolCall: {
+          tool: 'generator',
+          params: { model: model }
+        }
+      }
+    ],
+    cursor: 2, // All steps completed
+    history: [],
+    resources: {}
+  };
+
+  // Generate a mock response based on the prompt
+  let finalAnswer = '';
+  if (userGoal.toLowerCase().includes('joke')) {
+    finalAnswer = "Why don't scientists trust atoms? Because they make up everything!";
+  } else if (userGoal.toLowerCase().includes('hello')) {
+    finalAnswer = `Hello! I'm a mock orchestrator using ${model}. Your goal was: "${userGoal}"`;
+  } else {
+    finalAnswer = `Mock response from ${model}: I received your request "${userGoal}". In a real implementation, this would process through the full orchestration pipeline with planning, execution, and safety checks.`;
+  }
+
+  return {
+    ok: true,
+    next_action: 'done',
+    final_answer: finalAnswer,
+    state: state,
+    events: events
+  };
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { userGoal, config } = body;
+
+    if (!userGoal) {
+      return NextResponse.json(
+        { error: 'userGoal is required' },
+        { status: 400 }
+      );
+    }
+
+    const model = config?.model || 'claude-3-haiku-20240307';
+
+    // Use mock orchestrator for testing
+    const response = await mockOrchestrate(userGoal, model);
+
+    return NextResponse.json(response);
+
+  } catch (error: any) {
+    console.error('Test orchestration error:', error);
+    return NextResponse.json(
+      { 
+        error: 'Orchestration failed',
+        message: error.message 
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Added toggle switch for "Full Test Mode" to test orchestrator flow alongside existing direct API testing
- Created mock orchestrator endpoint that simulates the orchestration pipeline without external dependencies
- Enhanced UI to display orchestrator-specific information when in full test mode

## Changes
- **Updated `/app/test-anthropic/page.tsx`**: Added toggle switch and orchestrator-specific UI components
- **Created `/app/api/test-orchestrator/route.ts`**: Mock orchestrator endpoint for testing without database/OpenAI dependencies

## Test Plan
- [x] Test direct API mode (toggle OFF) - works as before
- [x] Test orchestrator mode (toggle ON) - shows mock orchestration flow
- [x] Verify UI properly displays execution plan and event timeline
- [x] Confirm no authentication errors in test mode

🤖 Generated with [Claude Code](https://claude.ai/code)